### PR TITLE
Fix "can't push to protected branch" issue

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -48,7 +48,7 @@ jobs:
         pip install -r requirements.txt
             
     - name: Tweet
-      if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main'
+      if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'schedule'
       run: |
         cd bot
         python tweet_plot.py

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -65,7 +65,7 @@ jobs:
       if: "!contains(github.event.head_commit.message, 'ci skip') && github.ref == 'refs/heads/main'"
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
         branch: ${{ github.ref }}      
 
     - name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ pybamm.print_citations()
 
 to the end of your script. This will print bibtex information to the terminal; passing a filename to `print_citations` will print the bibtex information to the specified file instead. A list of all citations can also be found in the [citations file](https://github.com/pybamm-team/PyBaMM/blob/develop/pybamm/CITATIONS.txt).
 
-## Contributing to PyBaMM-Twitter-Bot
+## Contributing to BattBot
 
 All contributions to this repository are welcome. You can go through our [contribution guidelines](https://github.com/Saransh-cpp/BattBot/blob/main/CONTRIBUTING.md) to make the whole process smoother.


### PR DESCRIPTION
## Changes/Additions
1. The workflows were not able to push the changes directly to the main branch because it is protected, hence the tests are failing (https://github.com/Saransh-cpp/BattBot/runs/3001385250?check_suite_focus=true). I am now trying to push the changes using my personal GitHub token (which should work as I am the repository owner) which I have added in the repository secrets.
2. Tweet now occurs only when running on schedule and not when a PR is merged.