### PR TITLE
Fixing `Heroku` deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-start: cd bot; python reply_tweet.py
+start: cd bot; python tweet_reply.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ git+git://github.com/pybamm-team/PyBaMM.git@develop
 tweepy==3.10.0
 pillow==8.0.1
 imageio==2.9.0
+coverage==5.5


### PR DESCRIPTION
I tried deploying the `main` branch on `Heroku` as #41 is merged now. The build was successful but running the commands in `Procfile` gave 2 errors - 

1. `ModuleNotFoundError: No module named 'coverage'`
This PR adds the same in `requirements.txt`.
2. `python: can't open file '/app/bot/reply_tweet.py': [Errno 2] No such file or directory`
The file is named `tweet_reply.py`, this PR fixes the typo.

```Heroku
2021-07-22T18:03:33.000000+00:00 app[api]: Build started by user pybammbattbot@gmail.com
2021-07-22T18:06:00.029601+00:00 app[api]: Release v3 created by user pybammbattbot@gmail.com
2021-07-22T18:06:00.029601+00:00 app[api]: Deploy 9ba9695b by user pybammbattbot@gmail.com
2021-07-22T18:06:51.000000+00:00 app[api]: Build succeeded
2021-07-22T18:07:15.315587+00:00 app[api]: Scaled to start@1:Free by user pybammbattbot@gmail.com
2021-07-22T18:07:37.252630+00:00 heroku[start.1]: Starting process with command `cd bot; python reply_tweet.py`
2021-07-22T18:07:38.107436+00:00 heroku[start.1]: State changed from starting to up
2021-07-22T18:07:40.473533+00:00 heroku[start.1]: Process exited with status 2
2021-07-22T18:07:40.582791+00:00 heroku[start.1]: State changed from up to crashed
2021-07-22T18:07:40.610135+00:00 heroku[start.1]: State changed from crashed to starting
2021-07-22T18:07:40.404613+00:00 app[start.1]: Error in sitecustomize; set PYTHONVERBOSE for traceback:
2021-07-22T18:07:40.404625+00:00 app[start.1]: ModuleNotFoundError: No module named 'coverage'
2021-07-22T18:07:40.405048+00:00 app[start.1]: python: can't open file '/app/bot/reply_tweet.py': [Errno 2] No such file or directory
```