### PR TITLE
Fix the failing CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -56,7 +56,7 @@ jobs:
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
         git pull origin main
-        git commit -m "Update config, data - ci skip" -a
+        git commit -m "Update config, data - [skip ci]" -a
       env:
         ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
         ACCESS_SECRET: ${{ secrets.ACCESS_SECRET }}
@@ -69,8 +69,9 @@ jobs:
         cd bot
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
+        git pull origin main
         python -m twitter_api.sync_last_seen_id
-        git commit --allow-empty -m "Update last_seen_id" -a
+        git commit --allow-empty -m "Update last_seen_id - [skip ci]" -a
       env:
         ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
         ACCESS_SECRET: ${{ secrets.ACCESS_SECRET }}
@@ -78,7 +79,7 @@ jobs:
         CONSUMER_SECRET: ${{ secrets.CONSUMER_SECRET }}
 
     - name: Push changes
-      if: "!contains(github.event.head_commit.message, 'ci skip') && github.ref == 'refs/heads/main'"
+      if: github.ref == 'refs/heads/main'
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/test/without_keys/test_comparison_generator.py
+++ b/test/without_keys/test_comparison_generator.py
@@ -76,22 +76,6 @@ class TestComparisonGenerator(unittest.TestCase):
 
         assert os.path.exists("plot.gif")
 
-        comparison_generator = ComparisonGenerator(
-            models_for_comp=self.models_for_comp,
-            chemistry=self.chemistry,
-            is_experiment=self.is_experiment,
-        )
-
-        comparison_generator.model_comparison()
-
-        self.assertIsInstance(
-            comparison_generator.comparison_dict["varied_values"], list
-        )
-        self.assertTrue(len(comparison_generator.comparison_dict["varied_values"]) == 0)
-        self.assertIsInstance(comparison_generator.comparison_dict["params"], dict)
-
-        assert os.path.exists("plot.gif")
-
         self.is_experiment = True
         comparison_generator = ComparisonGenerator(
             models_for_comp=self.model_for_comp,
@@ -134,6 +118,22 @@ class TestComparisonGenerator(unittest.TestCase):
         comparison_generator = ComparisonGenerator(
             models_for_comp=self.models_for_comp,
             chemistry=pybamm.parameter_sets.Ai2020,
+            is_experiment=self.is_experiment,
+            cycle=self.cycle,
+            number=self.number,
+        )
+
+        comparison_generator.model_comparison()
+
+        self.assertIsInstance(
+            comparison_generator.comparison_dict["varied_values"], list
+        )
+        self.assertTrue(len(comparison_generator.comparison_dict["varied_values"]) == 0)
+        self.assertIsInstance(comparison_generator.comparison_dict["params"], dict)
+
+        comparison_generator = ComparisonGenerator(
+            models_for_comp=self.models_for_comp,
+            chemistry=self.chemistry,
             is_experiment=self.is_experiment,
             cycle=self.cycle,
             number=self.number,


### PR DESCRIPTION
Skip the whole CI on push to main, if the commit says `"[skip ci]"`.

It is really hard to test these workflows as they never run on a PR but I think this should work. This feature was recently added to GitHub - [CHANGELOG/Documentation for the  feature](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/)

This should hopefully fix the weird CI problems.